### PR TITLE
Add ability to reload `open` state from node.

### DIFF
--- a/src/flatten.js
+++ b/src/flatten.js
@@ -93,6 +93,10 @@ const flatten = (nodes = [], options = {}) => {
                 if (openAllNodes) {
                     return true;
                 }
+                // determine from input
+                if (node.state && node.state.open) {
+                    return true;
+                }
                 // determine by node object
                 if (openNodes.indexOf(node) >= 0) {
                     return true;


### PR DESCRIPTION
Currently InfiniteTree.loadData calls `flatten` without the `openNodes` property, so there is really no way to set an `open` state without calling InfiniteTree.openNode after loading the data. Instead of making the developer send in `nodes` and a separate object of `openNodes`. This patch just allows people to use the same interface `node` has once it's loaded up to set the `open` state. This is useful when `autoOpen = false`.